### PR TITLE
Fix string only parameter in $.toaster call

### DIFF
--- a/jquery.toaster.js
+++ b/jquery.toaster.js
@@ -162,6 +162,14 @@
 			{
 				toasting.notify(title, message, priority);
 			}
+		} else if (typeof options === "string") {
+		    var title = 'Notice';
+		    var message = options;
+		    var priority = 'success';
+
+		    if (message !== null) {
+		        toasting.notify(title, message, priority);
+		    }
 		}
 	};
 


### PR DESCRIPTION
The $.toaster function only checks for whether the incoming parameter is an object. In the Usage section of the README it mentions that a string can be passed to use default values.
I have implemented this small change.

Section from README:
/*
- ...or pass only a string; it will be treated as the intended message,
- and 'priority' will default to 'success', and 'title' to 'Notice'.
  */
  $.toaster('Whatever you did worked!');
